### PR TITLE
[TECH] Modifier le parsing des logs du frontal Nginx

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -1,3 +1,0 @@
-location / {
-     proxy_pass <%= ENV["OVH_BUCKET_URL"] %>;
-}

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -1,0 +1,26 @@
+log_format keyvalue
+  'method=$request_method'
+  ' path="$request_uri"'
+  ' host=$host'
+  ' request_id=$http_x_request_id'
+  ' from="$remote_addr"'
+  ' protocol=$scheme'
+  ' status=$status'
+  ' duration=${request_time}s'
+  ' bytes=$bytes_sent'
+  ' referer="$http_referer"'
+  ' user_agent="$http_user_agent"';
+
+access_log off;
+
+server {
+  server_name localhost;
+  listen <%= ENV['PORT'] %>;
+
+  charset utf-8;
+  access_log logs/access.log keyvalue;
+  
+  location / {
+      proxy_pass <%= ENV["OVH_BUCKET_URL"] %>;
+  }
+}

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -3,7 +3,7 @@ log_format keyvalue
   ' path="$request_uri"'
   ' host=$host'
   ' request_id=$http_x_request_id'
-  ' from="$realip_remote_addr"'
+  ' from="$remote_addr"'
   ' protocol=$scheme'
   ' status=$status'
   ' duration=${request_time}s'
@@ -14,7 +14,18 @@ log_format keyvalue
 access_log off;
 
 server {
+  # Scalingo Router
+  set_real_ip_from 10.0.0.0/8;
+
+  # Baleen https://support.baleen.cloud/hc/fr/articles/360016930920-Quelles-sont-les-plages-d-IP-de-Baleen-
+  set_real_ip_from 185.179.148.0/22;
+  set_real_ip_from 185.231.164.0/22;
+
+  real_ip_header X-Forwarded-For;
+  real_ip_recursive on;
+
   server_name localhost;
+
   listen <%= ENV['PORT'] %>;
 
   charset utf-8;

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -3,7 +3,7 @@ log_format keyvalue
   ' path="$request_uri"'
   ' host=$host'
   ' request_id=$http_x_request_id'
-  ' from="$remote_addr"'
+  ' from="$realip_remote_addr"'
   ' protocol=$scheme'
   ' status=$status'
   ' duration=${request_time}s'


### PR DESCRIPTION
## :christmas_tree: Problème
Les logs de pix-proxy-dlpixfr-production ne sont pas correctement parsés pas dans datadog

## :gift: Solution
Modifier la conf afin de parser correctement les logs 
