### PR TITLE
[BUG FIX] Ajout de CORS header (PIX-4659)

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -32,6 +32,8 @@ server {
   access_log logs/access.log keyvalue;
   
   location / {
+      proxy_hide_header 'access-control-allow-origin';
+
       add_header 'access-control-allow-origin' * always;
 
       proxy_pass <%= ENV["OVH_BUCKET_URL"] %>;

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -32,6 +32,8 @@ server {
   access_log logs/access.log keyvalue;
   
   location / {
+      add_header 'access-control-allow-origin' * always;
+
       proxy_pass <%= ENV["OVH_BUCKET_URL"] %>;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Dans certain cas OVH ne renvoie pas le header 'access-control-allow-origin'.

## :robot: Solution
Nous l'avons donc ajouter par défaut.

## :rainbow: Remarques
RAS

## :100: Pour tester
Faire un `CURL` et vérifier la présence du header 'access-control-allow-origin'.
