### PR TITLE
:sparkles: Pouvoir modifier dynamiquement les délais de mise en quarantaine

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -9,33 +9,36 @@ log_format keyvalue
   ' duration=${request_time}s'
   ' bytes=$bytes_sent'
   ' referer="$http_referer"'
-  ' user_agent="$http_user_agent"';
+  ' user_agent="$http_user_agent"'<%#
+    To allow dynamic logging format for nginx,
+    create a json that contains the key/value pairs
+    you want to add to nginx logging.
+    For the logs to be correctly parsed, use the nginx_logger_version parameter.
+    For example:
+    ADDITIONAL_NGINX_LOGS='{"nginx_logger_version":"1", "my_custom_header":"$http_my_custom_header"}'
+  %><%
+    require 'json';
+    JSON.parse(ENV['ADDITIONAL_NGINX_LOGS']||'{}').each do |nginx_key,value| %>
+  ' <%= nginx_key %>="<%= value %>"'<% end %>;
 
 access_log off;
 
+upstream bucket {
+    server <%= ENV["OVH_BUCKET_HOST"] %>:443 max_fails=<%= ENV['NGINX_UPSTREAM_MAX_FAILS'] || 3 %> fail_timeout=<%= ENV['NGINX_UPSTREAM_FAIL_TIMEOUT'] || '5s' %>;
+}
+
 server {
-  # Scalingo Router
-  set_real_ip_from 10.0.0.0/8;
-
-  # Baleen https://support.baleen.cloud/hc/fr/articles/360016930920-Quelles-sont-les-plages-d-IP-de-Baleen-
-  set_real_ip_from 185.179.148.0/22;
-  set_real_ip_from 185.231.164.0/22;
-
-  real_ip_header X-Forwarded-For;
-  real_ip_recursive on;
-
+  access_log logs/access.log keyvalue;
   server_name localhost;
-
   listen <%= ENV['PORT'] %>;
 
   charset utf-8;
-  access_log logs/access.log keyvalue;
   
   location / {
       proxy_hide_header 'access-control-allow-origin';
 
       add_header 'access-control-allow-origin' * always;
 
-      proxy_pass <%= ENV["OVH_BUCKET_URL"] %>;
+      proxy_pass https://bucket<%= ENV["OVH_BUCKET_PATH"] %>;
   }
 }


### PR DESCRIPTION
## :christmas_tree: Problème
En cas de problème sur un backend, les règles de mises en quarantaine par défaut de proxy (nginx) sont trop impactantes.

## :gift: Proposition
Rendre ces règles de proxy dynamiques.

## :star2: Remarques
On ajoute également les dernières modifications apportées aux logs sur le monorepo.

## :santa: Pour tester
Vérifier sur [l'application d'intégration](https://dashboard.scalingo.com/apps/osc-fr1/pix-proxy-s3-recette/) que: 
- les logs fonctionnent (voir la variable [ADDITIONAL_NGINX_LOGS](https://dashboard.scalingo.com/apps/osc-fr1/pix-proxy-s3-recette/environment));
- les documents (de test) sont bien accessibles.
