### PR TITLE
:wrench: Disable proxy-buffering

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -40,5 +40,6 @@ server {
       add_header 'access-control-allow-origin' * always;
 
       proxy_pass https://bucket<%= ENV["OVH_BUCKET_PATH"] %>;
+      proxy_buffering off;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Certaines requêtes finissent en 504 parce que la réponse n'est pas renvoyée dans les 60 secondes et que le router scalingo coupe la requête

## :robot: Proposition
Streamer la réponse plutôt que de la bufferiser

## :100: Pour tester
Déployer cette branche et accéder à des fichiers du bucket 

Exemple : 
- https://pix-proxy-dl-recette.osc-fr1.scalingo.io/recWXzf3tqsBu4a0P1629899226263/%40fichier4_r3.PNG
- https://pix-proxy-dl-recette.osc-fr1.scalingo.io/recOIrJmCnF5EHQb61623769789938/Pix_rectangle.docx
- https://pix-proxy-dl-recette.osc-fr1.scalingo.io/recuWjokQbAMAuwQZ1623769765780/Pix_lorem.odt