### PR TITLE
[TECH] optimisation des caches des proxy

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -34,10 +34,23 @@ server {
 
   charset utf-8;
   
+  location /robots.txt {
+      try_files /robots.txt =404;
+  }
+  
+  location /api/* {
+      return 404;
+  }
+
+  location ~* .(/favicon.ico|/apple-touch-icon.png|/apple-touch-icon-precomposed.png)$ {
+      return 404;
+  }
+
   location / {
       proxy_hide_header 'access-control-allow-origin';
 
       add_header 'access-control-allow-origin' * always;
+      add_header Cache-Control "public, max-age=172800";
 
       proxy_pass https://bucket<%= ENV["OVH_BUCKET_PATH"] %>;
       proxy_buffering off;


### PR DESCRIPTION
## 🌸 Problème
Les configurations des caches sont non optimales pour exploiter au max le CDN.

## 🌳 Proposition

1. Forcer la mise en cache pour 2J. 
2. répondre en 404 sur les ressources inexistantes les plus appelées sans ping les S3.
3. Ajouter un robots.txt pour disallow le crawling par les robots sur tous les buckets de manière systématique